### PR TITLE
Expose fields

### DIFF
--- a/src/Honeycomb/Api/Types/RequestOptions.hs
+++ b/src/Honeycomb/Api/Types/RequestOptions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
 module Honeycomb.Api.Types.RequestOptions
-    ( RequestOptions
+    ( RequestOptions (..)
     , mkRequestOptions
     , requestApiHostL
     , requestApiDatasetL

--- a/src/Honeycomb/Core/Types/Honey.hs
+++ b/src/Honeycomb/Core/Types/Honey.hs
@@ -1,5 +1,5 @@
 module Honeycomb.Core.Types.Honey
-    ( Honey
+    ( Honey (..)
     , mkHoney
     , honeyOptionsL
     , honeyTransportStateL

--- a/src/Honeycomb/Core/Types/HoneyOptions.hs
+++ b/src/Honeycomb/Core/Types/HoneyOptions.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Honeycomb.Core.Types.HoneyOptions
-    ( HoneyOptions
+    ( HoneyOptions (..)
     , apiKeyL
     , datasetL
     , sampleRateL

--- a/src/Honeycomb/Core/Types/HoneyServerOptions.hs
+++ b/src/Honeycomb/Core/Types/HoneyServerOptions.hs
@@ -1,5 +1,5 @@
 module Honeycomb.Core.Types.HoneyServerOptions
-    ( HoneyServerOptions
+    ( HoneyServerOptions (..)
     , blockOnResponseL
     , maxBatchSizeL
     , sendFrequencyL

--- a/src/Honeycomb/Core/Types/TransportState.hs
+++ b/src/Honeycomb/Core/Types/TransportState.hs
@@ -1,5 +1,5 @@
 module Honeycomb.Core.Types.TransportState
-    ( TransportState
+    ( TransportState (..)
     , transportSendQueueL
     , transportResponseQueueL
     , transportFlushQueueL


### PR DESCRIPTION
This allows users to configure the library without using lenses.