### PR TITLE
Limit size of payload being sent to Honeycomb

### DIFF
--- a/honeycomb.cabal
+++ b/honeycomb.cabal
@@ -77,6 +77,8 @@ library
       Honeycomb.Api.Types.HoneyObject
       Honeycomb.Api.Types.HoneyValue
       Honeycomb.Api.Types.RequestOptions
+      Honeycomb.Api.Types.SendEventsResponse
+      Honeycomb.Api.Types.SendEventsServerReply
       Honeycomb.Trace
       Honeycomb.Trace.Types
       Honeycomb.Trace.Types.ServiceName

--- a/src/Honeycomb/Api/Events.hs
+++ b/src/Honeycomb/Api/Events.hs
@@ -11,29 +11,62 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import GHC.Int (Int64)
 import Honeycomb.Api.Types
 import Lens.Micro ((^.))
 import qualified Network.HTTP.Client as Client
 import Network.HTTP.Types.Header (RequestHeaders)
 import Network.URI (normalizeEscape)
 
+maxEntryLength :: Int64
+maxEntryLength = 100000
+
+maxBodyLength :: Int64
+maxBodyLength = 5000000
+
 sendEvents ::
   MonadIO m =>
   (Client.Request -> m (Client.Response LBS.ByteString)) ->
   RequestOptions ->
   [Event] ->
-  m (Client.Response (Maybe [Integer]))
+  m SendEventsResponse
 sendEvents httpLbs requestOptions events = do
   initReq <- liftIO $ Client.parseRequest batchUri
-  response <- httpLbs $ newReq initReq
-  pure $ JSON.decode' <$> response
+  let (unsent, dropped, body) = createBodyFromEvents True events [] "[" 1
+  response <- httpLbs $ newReq initReq $ body <> "]"
+  pure SendEventsResponse
+    { unsentEvents = unsent,
+      oversizedEvents = dropped,
+      serviceResponse = JSON.decode <$> response
+    }
   where
-    newReq :: Client.Request -> Client.Request
-    newReq initReq =
+    createBodyFromEvents :: Bool -> [Event] -> [Event] -> LBS.ByteString -> Int64 -> ([Event], [Event], LBS.ByteString)
+    createBodyFromEvents isFirst toSend dropped bs bsLength =
+      case toSend of
+        [] -> ([], dropped, bs)
+        l@(hd : tl) ->
+          let newEncoded = JSON.encode hd
+              newEncodedLength = LBS.length newEncoded
+              newBS =
+                if isFirst
+                  then bs <> JSON.encode hd
+                  else bs <> "," <> JSON.encode hd
+              newBSLength =
+                if isFirst
+                  then bsLength + newEncodedLength
+                  else bsLength + 1 + newEncodedLength
+           in if newEncodedLength > maxEntryLength
+                then createBodyFromEvents isFirst tl (hd : dropped) bs bsLength
+                else
+                  if newBSLength + 1 >= maxBodyLength
+                    then (l, dropped, bs)
+                    else createBodyFromEvents False tl dropped newBS newBSLength
+    newReq :: Client.Request -> LBS.ByteString -> Client.Request
+    newReq initReq body =
       initReq
         { Client.method = "POST",
           Client.requestHeaders = additionalRequestHeaders <> Client.requestHeaders initReq,
-          Client.requestBody = Client.RequestBodyLBS $ JSON.encode events
+          Client.requestBody = Client.RequestBodyLBS body
         }
     batchUri = (T.unpack . coerce $ requestOptions ^. requestApiHostL) <> "1/batch/" <> batchPath
     batchPath = normalizeEscape . T.unpack . coerce $ requestOptions ^. requestApiDatasetL

--- a/src/Honeycomb/Api/Types.hs
+++ b/src/Honeycomb/Api/Types.hs
@@ -6,6 +6,8 @@ module Honeycomb.Api.Types
     module Honeycomb.Api.Types.HoneyObject,
     module Honeycomb.Api.Types.HoneyValue,
     module Honeycomb.Api.Types.RequestOptions,
+    module Honeycomb.Api.Types.SendEventsResponse,
+    module Honeycomb.Api.Types.SendEventsServerReply,
   )
 where
 
@@ -16,3 +18,5 @@ import Honeycomb.Api.Types.Event
 import Honeycomb.Api.Types.HoneyObject
 import Honeycomb.Api.Types.HoneyValue
 import Honeycomb.Api.Types.RequestOptions
+import Honeycomb.Api.Types.SendEventsResponse
+import Honeycomb.Api.Types.SendEventsServerReply

--- a/src/Honeycomb/Api/Types/HoneyValue.hs
+++ b/src/Honeycomb/Api/Types/HoneyValue.hs
@@ -8,7 +8,7 @@ module Honeycomb.Api.Types.HoneyValue
 where
 
 import qualified Data.Aeson as JSON
-import Data.Aeson.Types (prependFailure, typeMismatch)
+import Data.Aeson.Types (modifyFailure, typeMismatch)
 import Data.Scientific (Scientific, fromFloatDigits)
 import Data.String (IsString, fromString)
 import qualified Data.Text as T
@@ -77,6 +77,6 @@ instance JSON.FromJSON HoneyValue where
   parseJSON (JSON.Number n) = pure $ HoneyNumber n
   parseJSON (JSON.Bool b) = pure $ HoneyBool b
   parseJSON invalid@(JSON.Array _) =
-    prependFailure "parsing HoneyValue failed, " (typeMismatch "Array" invalid)
+    modifyFailure ("parsing HoneyValue failed, " ++) (typeMismatch "Array" invalid)
   parseJSON invalid@(JSON.Object _) =
-    prependFailure "parsing HoneyValue failed, " (typeMismatch "Object" invalid)
+    modifyFailure ("parsing HoneyValue failed, " ++) (typeMismatch "Object" invalid)

--- a/src/Honeycomb/Api/Types/SendEventsResponse.hs
+++ b/src/Honeycomb/Api/Types/SendEventsResponse.hs
@@ -1,0 +1,12 @@
+module Honeycomb.Api.Types.SendEventsResponse where
+
+import Honeycomb.Api.Types.Event
+import Honeycomb.Api.Types.SendEventsServerReply
+import qualified Network.HTTP.Client as Client
+
+data SendEventsResponse
+  = SendEventsResponse
+      { unsentEvents :: ![Event],
+        oversizedEvents :: ![Event],
+        serviceResponse :: !(Client.Response (Maybe [SendEventsServerReply]))
+      }

--- a/src/Honeycomb/Api/Types/SendEventsServerReply.hs
+++ b/src/Honeycomb/Api/Types/SendEventsServerReply.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Honeycomb.Api.Types.SendEventsServerReply where
+
+import qualified Data.Aeson as JSON
+import Data.Aeson ((.:))
+import qualified Data.Text as T
+
+data SendEventsServerReply
+  = SendEventsServerReply
+      { serverReplyStatus :: !Int,
+        serverReplyError :: !(Maybe T.Text)
+      }
+  deriving (Show)
+
+instance JSON.FromJSON SendEventsServerReply where
+  parseJSON = JSON.withObject "SendEventsServerReply" $ \v ->
+    SendEventsServerReply
+      <$> v .: "status"
+      <*> v .: "error"

--- a/test/ApiSpec.hs
+++ b/test/ApiSpec.hs
@@ -45,7 +45,7 @@ spec =
         jsons <- readIORef jsonsRef
         List.all isJust jsons `shouldBe` True
   where
-    sendEventsAndCheckJSON :: IORef [Maybe [Event]] -> [Event] -> IO (Client.Response (Maybe [Integer]))
+    sendEventsAndCheckJSON :: IORef [Maybe [Event]] -> [Event] -> IO SendEventsResponse
     sendEventsAndCheckJSON requestsRef =
       sendEvents (httpLbsJSONRequests requestsRef) requestOptions
     requestOptions :: RequestOptions
@@ -59,6 +59,8 @@ spec =
     httpLbsJSONRequests :: IORef [Maybe [Event]] -> Client.Request -> IO (Client.Response LBS.ByteString)
     httpLbsJSONRequests ref req = do
       case Client.requestBody req of
-        Client.RequestBodyLBS b -> modifyIORef ref (<> [JSON.decode b :: Maybe [Event]]) -- O(N^2) I know
-        _ -> pure ()
+        Client.RequestBodyLBS b ->
+          modifyIORef ref (<> [JSON.decode b :: Maybe [Event]])
+        _ ->
+          pure ()
       pure undefined


### PR DESCRIPTION
As per https://docs.honeycomb.io/api/events/ the limits on individual message size is 100KB, and the limit on the overall batch size is 5MB.

This code drops individual messages which are too large, and sends multiple batch requests if a single batch request would be too large.

 - [x] Drop messages which are larger than individual message size
 - [x] Don't send batch requests larger than batch message size
 - [x] Send followup batch requests with messages that are missing
 - [x] Test these